### PR TITLE
3 new facet variants (object, tuple, term)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 ### Real-world examples
 Icelastic is used in production at the Norwegian Polar Institute [API](http://api.npolar.no)s, below are some real-world example queries
 * [Searching](http://api.npolar.no/dataset/?q=glacier) **?q=**
-* [Filtering](http://api.npolar.no/oceanography/?q=&filter-collection=cast&filter-station=77) filter-{variable}=value 
+* [Filtering](http://api.npolar.no/oceanography/?q=&filter-collection=cast&filter-station=77) filter-{variable}=value
 * [Faceting](http://api.npolar.no/oceanography/?q=&facets=collection,station,sea_water_temperature) facets={variable[,varible2]}
-* [Range-faceting](http://api.npolar.no/oceanography/?q=&rangefacet-sea_water_temperature=10,&rangefacet-latitude=10) (aka. bucketing) 
+* [Range-faceting](http://api.npolar.no/oceanography/?q=&rangefacet-sea_water_temperature=10,&rangefacet-latitude=10) (aka. bucketing)
 
-### Multiple response formats 
+### Multiple response formats
 The default Icelastic response format is a [JSON feed]() modeled after Atom/[OpenSearch](http://www.opensearch.org/Specifications/OpenSearch/1.1#Example_of_OpenSearch_response_elements_in_Atom_1.0).
 
 * [JSON](http://api.npolar.no/dataset/?q=&format=json) format=json
@@ -60,19 +60,19 @@ use ::Rack::Icelastic, {
 
 module My
   class ElasticsearchCDLWriter
-    
+
     def self.format
       "cdl"
     end
-    
+
     def self.type
       "text/plain"
     end
-    
+
     def initialize(request, elasticsearch_response_hash)
       @feed = Icelastic::ResponseWriter::Feed.new(request, elasticsearch_response_hash)
     end
-          
+
     def build
       @feed.build do |feed|
         "netcdf {}" # build response here
@@ -128,13 +128,14 @@ end
   "?date-<interval>=<field1>,<field2>" # Generate a date facet with the specified interval (year|month|day)
 
   "?size-facet=<number>" # Specify the number of facets to return
+  "?facet.variant=<variant>" # Available variants: object,tuple, term
 ```
 
 #### Aggregations
 
 ```ruby
   "?date-<interval>=<field>[<field1>:<field2>]" # Specify a temporal aggregation
-  
+
   "?rangefacet-<field>=<interval>" # Range facet with interval
 ```
 

--- a/lib/icelastic/default.rb
+++ b/lib/icelastic/default.rb
@@ -4,8 +4,8 @@ module Icelastic
     DEFAULT_PARAMS = {
       "start" => 0,
       "limit" => 100,
-      "size-facet" => 10,
-      "variant" => "legacy"
+      "size-facet" => 10, # deprecated for facet.limit
+      "variant" => "legacy" # legacy|atom affects opensearch links to self next etc.
     }
 
     GEO_PARAMS = {

--- a/lib/icelastic/query_segment/aggregation.rb
+++ b/lib/icelastic/query_segment/aggregation.rb
@@ -37,7 +37,11 @@ module Icelastic
       private
 
       def aggregation_size
+        if params.key? "facet.limit"
+          params["facet.limit"].to_i
+        else
          extract_params(SIZE_REGEX).values.first.to_i  if extract_params(SIZE_REGEX).any?
+        end
       end
 
       def enabled?

--- a/lib/icelastic/response_writer/feed.rb
+++ b/lib/icelastic/response_writer/feed.rb
@@ -210,22 +210,28 @@ module Icelastic
         body_hash["aggregations"].map{|facet , obj| {facet => parse_buckets(facet, obj["buckets"])}}
       end
 
-      def facets_as_tuples
-        facets = {}
-        body_hash["aggregations"].each do |facet,b|
-          facets[facet] = b["buckets"].map {|bucket|
-            [ bucket["key"], bucket["doc_count"] ]
-          }
-        end
-        facets
+      def facets_as_terms
+        _facets_as_list({ count: false })
       end
 
-      def facets_as_terms
+      def facets_as_tuples
+        _facets_as_list({ count: true })
+      end
+
+      def _facets_as_list(arg = { count: true })
+        fo = facets_as_objects
         facets = {}
-        body_hash["aggregations"].each do |facet,b|
-          facets[facet] = b["buckets"].map {|bucket|
-            bucket["key"]
-          }
+        fo.keys.each do |k|
+          if fo.key? k and not fo[k].nil?
+            facets[k] = fo[k].map {|o|
+              if arg[:count]
+                v = [ o["term"],o["count"] ]
+              else
+                v = o["term"]
+              end
+              v
+            }
+          end
         end
         facets
       end

--- a/spec/icelastic/response_writer/feed_spec.rb
+++ b/spec/icelastic/response_writer/feed_spec.rb
@@ -172,7 +172,43 @@ describe Icelastic::ResponseWriter::Feed do
 
   end
 
-  context "#facets" do
+  context "#facets (facet.variant=object)" do
+
+    subject(:facets) { feed_factory("q=foo&facets=tags&facet.variant=object").facets }
+    it "a facet object should have the keys: term, uri, count" do
+      expect(facets).to be_a(Hash)
+      expect(facets).to have_key("tags")
+      expect(facets["tags"].length).to eq(2)
+      expect(facets["tags"].all? {|t| t.key? "term" and t.key? "uri" and t.key? "count" }).to eq(true)
+    end
+    it {
+      expect(facets["tags"][0]).to eq({"term"=>"foo", "count"=>88, "uri"=>"http://example.org/endpoint?q=foo&facets=tags&facet.variant=object&filter-tags=foo"})
+    }
+
+  end
+
+  context "#facets (facet.variant=tuple)" do
+
+    subject(:facets) { feed_factory("q=foo&facets=tags&facet.variant=tuple").facets }
+    it "a facet tuple should consist of [term,count]" do
+      expect(facets).to be_a(Hash)
+      expect(facets).to have_key("tags")
+      expect(facets["tags"].length).to eq(2)
+      expect(facets["tags"].all? {|t| t[1].is_a? Fixnum }).to eq(true)
+    end
+    it {
+      expect(facets["tags"][0]).to eq(["foo", 88])
+    }
+  end
+
+  context "#facets (facet.variant=term)" do
+    subject(:facets) { feed_factory("q=foo&facets=tags&facet.variant=term").facets }
+    it {
+      expect(facets["tags"][0]).to eq("foo")
+    }
+  end
+
+  context "#facets [LEGACY]" do
 
     subject(:facets) { feed_factory("q=foo&facets=tags").facets }
 


### PR DESCRIPTION
facet.variant=object
Implements #11 

facet.variant=term
```json
{ "facets": { "expedition": ["N-ICE2015","Barneo-2016"] } }
```

facet.variant=tuple
```json
{ "facets": { "expedition": [
    ["N-ICE2015",124090],
    ["Barneo-2016",22583]
  ]
}
```
